### PR TITLE
Compatibility for vscode 1.5+

### DIFF
--- a/modules/commit-command.js
+++ b/modules/commit-command.js
@@ -27,7 +27,7 @@ module.exports = function(getSyncHelper) {
     }
 
     if(jsonCorrect) {
-        vscode.commands.executeCommand("workbench.files.action.closeFile");
+        vscode.commands.executeCommand("workbench.action.closeActiveEditor");
         helper.executeSync(getSyncHelper(), sync, options);
     }
 }


### PR DESCRIPTION
command "workbench.files.action.closeFile" is deprecated; switch to "workbench.action.closeActiveEditor"
